### PR TITLE
Fixes bug claiming interface

### DIFF
--- a/blackwidowcontrol.py
+++ b/blackwidowcontrol.py
@@ -51,8 +51,7 @@ class BlackWidow(object):
 		try:
 			if self.device.is_kernel_driver_active(USB_INTERFACE):
 				LOG("Kernel driver active; detaching it\n")
-
-			self.device.detach_kernel_driver(USB_INTERFACE)
+				self.device.detach_kernel_driver(USB_INTERFACE)
 			self.kernel_driver_detached = True
 
 			LOG("Claiming interface\n")


### PR DESCRIPTION
Currently the script tries to detach the kernel driver even if it is not active; this causes the script to crash.
This fixes it to only try to detach the kernel driver if it is actually active.
Tested on a real Razer Blackwidow 2014.