### PR TITLE
Add support for BlackWidow Ultimate 2012

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The script is known to work with the following BlackWidow editions:
 - regular edition (the ceapest one which has no background light)
 - the regular 2013 edition
 - BlackWidow Ultimate Stealth 2014
+- BlackWidow Ultimate 2012
 
 If you can confirm that those or other devices work or don't work, let me now by editing this file.
 

--- a/blackwidowcontrol.py
+++ b/blackwidowcontrol.py
@@ -11,13 +11,15 @@ USB_VALUE = 0x0300
 USB_INDEX = 0x2
 USB_INTERFACE = 2
 
-VENDOR_ID = 0x1532                        # Razer
-PRODUCT_ID_BLACK_WIDOW = 0x010e           # BlackWidow
-PRODUCT_ID_BLACK_WIDOW_ULTIMATE = 0x011a  # BlackWidow Ultimate
-PRODUCT_ID_BLACK_WIDOW_2013 = 0x011b      # BlackWidow 2013/2014
+VENDOR_ID = 0x1532                             # Razer
+PRODUCT_ID_BLACK_WIDOW = 0x010e                # BlackWidow
+PRODUCT_ID_BLACK_WIDOW_ULTIMATE = 0x011a       # BlackWidow Ultimate
+PRODUCT_ID_BLACK_WIDOW_ULTIMATE_2012 = 0x010d  # BlackWidow Ultimate 2012
+PRODUCT_ID_BLACK_WIDOW_2013 = 0x011b           # BlackWidow 2013/2014
 
 PRODUCTS = [("Black Widow", PRODUCT_ID_BLACK_WIDOW),
             ("Black Widow Ultimate", PRODUCT_ID_BLACK_WIDOW_ULTIMATE),
+            ("Black Widow Ultimate 2012", PRODUCT_ID_BLACK_WIDOW_ULTIMATE_2012),
             ("Black Widow 2013/2014", PRODUCT_ID_BLACK_WIDOW_2013)]
 
 LOG=sys.stderr.write


### PR DESCRIPTION
I have the 2012 version of BlackWidow Ultimate. Which have id 0x010D.

Output after `blackwidowcontrol.py -i`:
```
Found device: Black Widow Ultimate 2012
Kernel driver active; detaching it
Claiming interface
Sending initiation command
Data sent successfully
Releasing claimed interface
Reattaching the kernel driver
```

Macro keys work for me now.